### PR TITLE
Code and UI improvements

### DIFF
--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -7,7 +7,7 @@ import logging
 import re
 from src.models.entities.experiment import Experiment
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 
 class DataManager:
     def __init__(self):
@@ -19,7 +19,7 @@ class DataManager:
         self.data_dir = os.path.join(project_root, "experiments")
         if not os.path.exists(self.data_dir):
             os.makedirs(self.data_dir)
-            logging.info(f"创建实验数据目录: {self.data_dir}")
+            logger.info(f"创建实验数据目录: {self.data_dir}")
 
     def _sanitize(self, text: str) -> str:
         """
@@ -38,14 +38,14 @@ class DataManager:
         """
         experiments = []
         pattern = os.path.join(self.data_dir, "*.json")
-        logging.info(f"加载 JSON 文件，模式: {pattern}")
+        logger.info(f"加载 JSON 文件，模式: {pattern}")
 
         for file_path in glob.glob(pattern):
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
             except Exception as e:
-                logging.error(f"读取或解析失败: {file_path}，错误: {e}")
+                logger.error(f"读取或解析失败: {file_path}，错误: {e}")
                 continue
 
             # 检查字段完整性（兼容新旧字段名）
@@ -56,21 +56,21 @@ class DataManager:
                 data["created_at"] = data["date"]
                 
             if not all(k in data for k in required_fields):
-                logging.warning(f"文件缺少必要字段，跳过: {file_path}")
+                logger.warning(f"文件缺少必要字段，跳过: {file_path}")
                 continue
 
             try:
                 exp = Experiment.from_dict(data)
             except Exception as e:
-                logging.error(f"Experiment.from_dict 失败: {file_path}，错误: {e}")
+                logger.error(f"Experiment.from_dict 失败: {file_path}，错误: {e}")
                 continue
 
             # 将文件路径记录在 Experiment 对象里
             exp._file_path = file_path
             experiments.append(exp)
-            logging.info(f"成功加载实验: {file_path}，name={exp.name}")
+            logger.info(f"成功加载实验: {file_path}，name={exp.name}")
 
-        logging.info(f"共加载 {len(experiments)} 个实验")
+        logger.info(f"共加载 {len(experiments)} 个实验")
         return experiments
 
     def save_experiment(self, experiment: Experiment) -> None:
@@ -85,9 +85,9 @@ class DataManager:
         if isinstance(old_path, str) and os.path.isfile(old_path):
             try:
                 os.remove(old_path)
-                logging.debug(f"删除旧实验文件: {old_path}")
+                logger.debug(f"删除旧实验文件: {old_path}")
             except Exception as e:
-                logging.error(f"删除旧文件失败: {old_path}，错误: {e}")
+                logger.error(f"删除旧文件失败: {old_path}，错误: {e}")
 
         # 2. 构造新文件名基础
         date_str = experiment.date if hasattr(experiment, 'date') else str(experiment.created_at)[:10]
@@ -112,11 +112,11 @@ class DataManager:
         try:
             with open(full_path, "w", encoding="utf-8") as f:
                 json.dump(payload, f, ensure_ascii=False, indent=2)
-            logging.info(f"保存实验: {full_path}")
+            logger.info(f"保存实验: {full_path}")
             # 更新 experiment._file_path
             experiment._file_path = full_path
         except Exception as e:
-            logging.error(f"保存失败: {full_path}，错误: {e}")
+            logger.error(f"保存失败: {full_path}，错误: {e}")
             raise
 
     def delete_experiment(self, experiment: Experiment) -> None:
@@ -128,12 +128,12 @@ class DataManager:
         if isinstance(path, str) and os.path.isfile(path):
             try:
                 os.remove(path)
-                logging.info(f"已删除实验文件: {path}")
+                logger.info(f"已删除实验文件: {path}")
             except Exception as e:
-                logging.error(f"删除文件失败: {path}，错误: {e}")
+                logger.error(f"删除文件失败: {path}，错误: {e}")
                 raise
         else:
-            logging.warning(f"无法删除: 找不到 experiment._file_path={path}")
+            logger.warning(f"无法删除: 找不到 experiment._file_path={path}")
 
     def save_all_data(self, experiments=None):
         """保存所有实验数据"""
@@ -145,7 +145,7 @@ class DataManager:
             try:
                 self.save_experiment(experiment)
             except Exception as e:
-                logging.error(f"保存实验失败 {experiment.name}: {e}")
+                logger.error(f"保存实验失败 {experiment.name}: {e}")
 
     def get_experiments(self):
         """获取所有实验数据"""

--- a/src/models/nuclide.py
+++ b/src/models/nuclide.py
@@ -1,88 +1,20 @@
-import numpy as np
-from datetime import datetime, timedelta
-from ..core.constants import HALF_LIFE_TABLE
+"""Utility wrappers for nuclide calculations.
 
-def calculate_decayed_activity(initial_activity, time_minutes, isotope):
-    """
-    计算核素衰减后的活度
-    
-    参数:
-    initial_activity: 初始活度
-    time_minutes: 衰减时间（分钟）
-    isotope: 核素名称
-    
-    返回:
-    衰减后的活度
-    """
-    try:
-        half_life = HALF_LIFE_TABLE[isotope]
-        decay_constant = np.log(2) / half_life
-        return initial_activity * np.exp(-decay_constant * time_minutes)
-    except KeyError:
-        raise ValueError(f"未知核素: {isotope}")
+This module previously duplicated a number of helper functions.  To
+avoid code drift we simply re-export the implementations from
+``src.models.entities.nuclide``.
+"""
 
-def calculate_initial_activity(target_activity, time_minutes, isotope):
-    """
-    计算为了达到目标活度需要的初始活度
-    
-    参数:
-    target_activity: 目标活度
-    time_minutes: 衰减时间（分钟）
-    isotope: 核素名称
-    
-    返回:
-    所需的初始活度
-    """
-    try:
-        half_life = HALF_LIFE_TABLE[isotope]
-        decay_constant = np.log(2) / half_life
-        return target_activity / np.exp(-decay_constant * time_minutes)
-    except KeyError:
-        raise ValueError(f"未知核素: {isotope}")
+from .entities.nuclide import (
+    calculate_decayed_activity,
+    calculate_initial_activity,
+    calculate_time_to_target,
+    convert_activity_unit,
+)
 
-def calculate_time_to_target(initial_activity, target_activity, isotope):
-    """
-    计算达到目标活度所需的时间（分钟）
-    
-    参数:
-    initial_activity: 初始活度
-    target_activity: 目标活度
-    isotope: 核素名称
-    
-    返回:
-    达到目标活度所需的时间（分钟）
-    """
-    if initial_activity <= target_activity:
-        return 0  # 如果初始活度小于目标活度，无法通过衰减达到
-    
-    try:
-        half_life = HALF_LIFE_TABLE[isotope]
-        decay_constant = np.log(2) / half_life
-        return np.log(initial_activity / target_activity) / decay_constant
-    except KeyError:
-        raise ValueError(f"未知核素: {isotope}")
-
-def convert_activity_unit(activity, from_unit, to_unit):
-    """
-    在不同活度单位之间转换
-    
-    参数:
-    activity: 活度值
-    from_unit: 源单位（"MBq", "mCi", "kBq", "Bq"）
-    to_unit: 目标单位（"MBq", "mCi", "kBq", "Bq"）
-    
-    返回:
-    转换后的活度值
-    """
-    from ..core.constants import ACTIVITY_UNITS
-    
-    # 查找转换因子
-    from_factor = next((factor for unit, factor in ACTIVITY_UNITS if unit == from_unit), None)
-    to_factor = next((factor for unit, factor in ACTIVITY_UNITS if unit == to_unit), None)
-    
-    if from_factor is None or to_factor is None:
-        raise ValueError(f"不支持的单位转换: {from_unit} -> {to_unit}")
-    
-    # 转换为MBq，再转换为目标单位
-    mbq_value = activity * from_factor
-    return mbq_value / to_factor 
+__all__ = [
+    "calculate_decayed_activity",
+    "calculate_initial_activity",
+    "calculate_time_to_target",
+    "convert_activity_unit",
+]

--- a/src/views/dialogs/add_experiment_dialog.py
+++ b/src/views/dialogs/add_experiment_dialog.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, 
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
     QLineEdit, QPushButton, QComboBox, QTextEdit,
-    QFrame, QGridLayout
+    QFrame, QGridLayout, QMessageBox
 )
 from PyQt5.QtCore import Qt
 from ...utils.time_utils import get_current_beijing_time
@@ -124,4 +124,11 @@ class AddExperimentDialog(QDialog):
     
     def get_experiment_data(self):
         """返回用户输入的实验数据 - 与get_data方法保持一致"""
-        return self.get_data() 
+        return self.get_data()
+
+    def accept(self):
+        """验证必填字段后再关闭对话框"""
+        if not self.name_input.text().strip() or not self.center_input.text().strip():
+            QMessageBox.warning(self, "提示", "实验名称和中心名称为必填项")
+            return
+        super().accept()

--- a/src/views/experiment/experiment_tabs/phantom_activity_tab.py
+++ b/src/views/experiment/experiment_tabs/phantom_activity_tab.py
@@ -9,7 +9,7 @@ import pytz
 import logging
 import numpy as np
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 
 class PhantomActivityTab(QWidget):
     def __init__(self, experiment, parent=None):
@@ -44,7 +44,7 @@ class PhantomActivityTab(QWidget):
             if hasattr(self.parent_widget, 'main_window') and hasattr(self.parent_widget.main_window, 'data_manager'):
                 self.parent_widget.main_window.data_manager.save_experiment(self.experiment)
         except Exception as e:
-            logging.error(f"保存实验失败: {e}")
+            logger.error(f"保存实验失败: {e}")
 
     def init_ui(self):
         """Initialize the UI layout."""
@@ -475,7 +475,7 @@ class PhantomActivityTab(QWidget):
             self._save_experiment()
             
         except Exception as e:
-            logging.error(f"计算总活度失败: {e}")
+            logger.error(f"计算总活度失败: {e}")
             QMessageBox.critical(self, "错误", f"计算总活度失败: {e}")
 
     def _refresh_syringe_widgets(self):
@@ -780,5 +780,5 @@ class PhantomActivityTab(QWidget):
             self.calculate_total_activity()
             
         except Exception as e:
-            logging.error(f"计算实际活度失败: {e}")
+            logger.error(f"计算实际活度失败: {e}")
             self.syringe_widgets[idx]["actual_display"].setText(f"计算错误") 

--- a/src/views/experiment/experiment_window.py
+++ b/src/views/experiment/experiment_window.py
@@ -18,11 +18,7 @@ from datetime import datetime, timedelta
 import pytz
 import numpy as np
 import logging
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logger = logging.getLogger(__name__)
 
 
 class ExperimentWindow(QWidget):
@@ -51,7 +47,7 @@ class ExperimentWindow(QWidget):
         
         self._init_ui()
         self._start_timer()
-        logging.info(f"初始化实验窗口: 单位={self.activity_unit}")
+        logger.info(f"初始化实验窗口: 单位={self.activity_unit}")
 
     def _init_ui(self):
         # 整个窗口的主垂直布局
@@ -241,7 +237,7 @@ class ExperimentWindow(QWidget):
                 dt = datetime.fromtimestamp(time_str, pytz.timezone('Asia/Shanghai'))
                 return QDateTime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
         except (ValueError, OSError) as e:
-            logging.error(f"时间解析错误: {e}")
+            logger.error(f"时间解析错误: {e}")
             
         return None
 
@@ -254,7 +250,7 @@ class ExperimentWindow(QWidget):
                 # 发出更新信号
                 self.experiment_updated.emit(self.experiment)
         except Exception as e:
-            logging.error(f"保存实验失败: {e}")
+            logger.error(f"保存实验失败: {e}")
 
     def _start_timer(self):
         """启动定时器，每秒更新一次时间和活度"""


### PR DESCRIPTION
## Summary
- replace duplicated nuclide helpers with simple re-export
- switch logging configuration to module loggers
- improve AddExperimentDialog with field validation
- tidy up phantom activity tab and experiment window logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fbad3f2b08320b96714fc0ed71b9e